### PR TITLE
Improve zeek-client's enum handling and add get-nodes command 

### DIFF
--- a/zeek-client
+++ b/zeek-client
@@ -467,14 +467,14 @@ class Node(BrokerType):
         def __hash__(self):
             return hash(frozenset(self))
 
-    def __init__(self, name, instance, role, port, state=State.RUNNING,
+    def __init__(self, name, instance, role, port=None, state=State.RUNNING,
                  scripts=None, options=None, interface=None, cpu_affinity=None,
                  env=None):
         self.name = name
         self.instance = instance
-        self.port = port
         self.role = role
         self.state = state
+        self.port = port
         self.scripts = scripts
         self.options = options
         self.interface = interface
@@ -488,10 +488,14 @@ class Node(BrokerType):
         # that we create only here, so won't modify after hashing.
         hdenv = Node.HashableDict(self.env.items())
 
+        port = None
+        if self.port is not None:
+            port = broker.Port(self.port, broker.Port.TCP)
+
         return (self.name, self.instance,
-                broker.Port(self.port, broker.Port.TCP),
                 self.role.to_broker(),
                 self.state.to_broker(),
+                port,
                 self.scripts,
                 self.options,
                 self.interface,
@@ -501,6 +505,7 @@ class Node(BrokerType):
     @staticmethod
     def from_config(parser, name):
         def get(typ, *keys):
+            """Typed config key/val retrieval, with support for key name aliases."""
             for key in keys:
                 val = parser.get(name, key, fallback=None)
                 if val is not None:
@@ -519,7 +524,8 @@ class Node(BrokerType):
         # Validate the specified values
         if not instance:
             raise ValueError('node "{}" requires an instance'.format(name))
-        if port is None or port < 1 or port > 65535:
+        # The listening port is optional
+        if port is not None and (port < 1 or port > 65535):
             raise ValueError('node "{}" port "{}" is invalid'.format(name, port))
 
         try:
@@ -534,7 +540,7 @@ class Node(BrokerType):
         except (AttributeError, KeyError) as err:
             raise ValueError('node "{}" state "{}" is invalid'.format(name, state_raw)) from err
 
-        return Node(name=name, instance=instance, port=port, role=role,
+        return Node(name=name, instance=instance, role=role, port=port,
                     state=state, interface=interface, cpu_affinity=cpu_affinity)
 
 

--- a/zeek-client
+++ b/zeek-client
@@ -33,6 +33,7 @@ import os.path
 import select
 import sys
 import time
+import traceback
 import uuid
 
 LOG = logging.getLogger(__name__)
@@ -212,6 +213,14 @@ class events:
     GetInstancesResponse = EventRegistry.make_event_class(
         'ClusterController::API::get_instances_response',
         ('reqid', 'result'), (str, tuple))
+
+    GetNodesRequest = EventRegistry.make_event_class(
+        'ClusterController::API::get_nodes_request',
+        ('reqid',), (str,))
+
+    GetNodesResponse = EventRegistry.make_event_class(
+        'ClusterController::API::get_nodes_response',
+        ('reqid', 'results'), (str, tuple))
 
     SetConfigurationRequest = EventRegistry.make_event_class(
         'ClusterController::API::set_configuration_request',
@@ -409,6 +418,17 @@ class ClusterRole(BrokerEnumType):
         return 'Supervisor'
 
 
+class ControllerRole(BrokerEnumType):
+    """Equivalent of ClusterController::Types::Role enum in Zeek"""
+    NONE = 0
+    AGENT = 1
+    CONTROLLER = 2
+
+    @classmethod
+    def module_scope(cls):
+        return 'ClusterController::Types'
+
+
 class State(BrokerEnumType):
     """Equivalent of ClusterController::Types::State enum in Zeek"""
     PENDING = 0
@@ -563,6 +583,31 @@ class Configuration(BrokerType):
         return (self.id, instances, nodes)
 
 
+class NodeStatus(BrokerType):
+    """Equivalent of ClusterController::Types::NodeState."""
+    def __init__(self, node, state, mgmt_role, cluster_role, pid=None, port=None):
+        self.node = node # A string containing the name of the node
+        self.state = state # A State enum value
+        self.mgmt_role = mgmt_role # A ControllerRole enum value
+        self.cluster_role = cluster_role # A ClusterRole enum value
+        self.pid = pid # A numeric process ID
+        self.port = port # A numeric (TCP) port
+
+    @classmethod
+    def from_broker(cls, broker_data):
+        # When a listening port is available, convert Broker's native port type
+        # to a plain integer. We're always dealing with TCP ports here.
+        port = broker_data[5].number() if broker_data[5] is not None else None
+
+        return NodeStatus(
+            broker_data[0],
+            State.from_broker(broker_data[1]),
+            ControllerRole.from_broker(broker_data[2]),
+            ClusterRole.from_broker(broker_data[3]),
+            broker_data[4],
+            port)
+
+
 class Result(BrokerType):
     """Equivalent of ClusterController::Types::Result."""
     def __init__(self, reqid, instance, success=True, data=None, error=None, node=None):
@@ -613,6 +658,65 @@ def cmd_get_instances(controller, args): # pylint: disable=unused-argument
 
     # Sort the list alphabetically by instance name
     json_data = sorted(json_data, key=lambda inst: inst['name'])
+
+    print(json_dumps(json_data))
+    return 0
+
+
+def cmd_get_nodes(controller, args):
+    controller.publish(events.GetNodesRequest(make_uuid()))
+    resp, msg = controller.receive()
+
+    if resp is None:
+        LOG.error('No response received: %s', msg)
+        return 1
+
+    if not isinstance(resp, events.GetNodesResponse):
+        LOG.error('Received unexpected event: %s', resp)
+        return 1
+
+    json_data = {}
+
+    for broker_data in resp.results:
+        res = Result.from_broker(broker_data)
+        if not res.success:
+            msg = ': ' + res.error if res.error else ''
+            if res.instance:
+                print_error('instance {} failure{}'.format(res.instance, msg))
+            else:
+                print_error('failure{}'.format(msg))
+            return 1
+
+        if res.data is None:
+            LOG.error('Received result did not contain NodeStatus vector data: %s', resp)
+            return 1
+
+        json_data[res.instance] = {}
+
+        # res.data is a NodeStatusVec
+        try:
+            for nstat_data in res.data:
+                nstat = NodeStatus.from_broker(nstat_data)
+
+                # If either of the two role enums are "NONE", we make them
+                # None. That way they stay in the reporting, but are more easily
+                # distinguished from "actual" values.
+                mgmt_role = nstat.mgmt_role if nstat.mgmt_role != ControllerRole.NONE else None
+                cluster_role = nstat.cluster_role if nstat.cluster_role != ClusterRole.NONE else None
+
+                json_data[res.instance][nstat.node] = {
+                    'state': nstat.state,
+                    'mgmt_role': mgmt_role,
+                    'cluster_role': cluster_role,
+                }
+
+                if nstat.pid is not None:
+                    json_data[res.instance][nstat.node]['pid'] = nstat.pid
+                if nstat.port is not None:
+                    json_data[res.instance][nstat.node]['port'] = nstat.port
+        except TypeError as err:
+            LOG.error('NodeStatus data invalid: %s', err)
+            LOG.debug(traceback.format_exc())
 
     print(json_dumps(json_data))
     return 0
@@ -782,6 +886,10 @@ def create_parser():
     sub_parser = command_parser.add_parser(
         'get-instances', help='Show instances connected to the controller.')
     sub_parser.set_defaults(run_cmd=cmd_get_instances)
+
+    sub_parser = command_parser.add_parser(
+        'get-nodes', help='Show active Zeek nodes at each instance.')
+    sub_parser.set_defaults(run_cmd=cmd_get_nodes)
 
     sub_parser = command_parser.add_parser(
         'monitor', help='For troubleshooting: do nothing, just report events.')

--- a/zeek-client
+++ b/zeek-client
@@ -508,18 +508,6 @@ class Result(BrokerType):
 
 # Command handlers
 
-def cmd_monitor(controller, args): # pylint: disable=unused-argument
-    while True:
-        resp, msg = controller.receive(None)
-
-        if resp is None:
-            print('no response received: {}'.format(msg))
-        else:
-            print('received "{}"'.format(resp))
-
-    return 0
-
-
 def cmd_get_instances(controller, args): # pylint: disable=unused-argument
     controller.publish(events.GetInstancesRequest(make_uuid()))
     resp, msg = controller.receive()
@@ -556,6 +544,18 @@ def cmd_get_instances(controller, args): # pylint: disable=unused-argument
     json_data = sorted(json_data, key=lambda inst: inst['name'])
 
     print(json_dumps(json_data))
+
+    return 0
+
+
+def cmd_monitor(controller, args): # pylint: disable=unused-argument
+    while True:
+        resp, msg = controller.receive(None)
+
+        if resp is None:
+            print('no response received: {}'.format(msg))
+        else:
+            print('received "{}"'.format(resp))
 
     return 0
 
@@ -708,27 +708,19 @@ def create_parser():
         title='commands', dest='command',
         help='See `%(prog)s <command> -h` for per-command usage info.')
 
-    # monitor
-
-    sub_parser = command_parser.add_parser(
-        'monitor', help='For troubleshooting: do nothing, just report events.')
-    sub_parser.set_defaults(run_cmd=cmd_monitor)
-
-    # instances
-
     sub_parser = command_parser.add_parser(
         'get-instances', help='Show instances connected to the controller.')
     sub_parser.set_defaults(run_cmd=cmd_get_instances)
 
-    # set-config
+    sub_parser = command_parser.add_parser(
+        'monitor', help='For troubleshooting: do nothing, just report events.')
+    sub_parser.set_defaults(run_cmd=cmd_monitor)
 
     sub_parser = command_parser.add_parser(
         'set-config', help='Deploy cluster configuration.')
     sub_parser.set_defaults(run_cmd=cmd_set_config)
     sub_parser.add_argument('config', metavar='FILE',
                             help='Cluster configuration file, "-" for stdin')
-
-    # test-timeout command
 
     sub_parser = command_parser.add_parser(
         'test-timeout', help='Send timeout test event.')
@@ -757,8 +749,6 @@ def configure_logger(args):
 
     LOG.addHandler(handler)
 
-
-# Main routine
 
 def main():
     parser = create_parser()

--- a/zeek-client
+++ b/zeek-client
@@ -362,8 +362,8 @@ class BrokerType:
         """Returns JSON-suitable datastructure representing the object."""
         return self.__dict__
 
-    @staticmethod
-    def from_broker(broker_data): # pylint: disable=unused-argument
+    @classmethod
+    def from_broker(cls, broker_data): # pylint: disable=unused-argument
         """Returns an instance of the type given Broker data. Raises TypeError when the
         given data doesn't match the type's expectations."""
         return None
@@ -387,8 +387,8 @@ class Instance(BrokerType):
         self.addr = addr or '0.0.0.0' # string or ipaddress type ... TBD
         self.port = port
 
-    @staticmethod
-    def from_broker(broker_data):
+    @classmethod
+    def from_broker(cls, broker_data):
         try:
             name, addr, port = broker_data
             return Instance(name, addr, port)
@@ -513,8 +513,8 @@ class Result(BrokerType):
         self.error = error
         self.node = node
 
-    @staticmethod
-    def from_broker(broker_data):
+    @classmethod
+    def from_broker(cls, broker_data):
         return Result(*broker_data)
 
 # Command handlers

--- a/zeek-client
+++ b/zeek-client
@@ -328,24 +328,6 @@ class Controller:
                     return None, 'status change: {}'.format(status)
 
 
-class Role(enum.Enum):
-    """Equivalent of Supervisor::ClusterRole enum in Zeek"""
-    NONE = 0
-    LOGGER = 1
-    MANAGER = 2
-    PROXY = 3
-    WORKER = 4
-
-
-class State(enum.Enum):
-    """Equivalent of ClusterController::Types::State enum in Zeek"""
-    RUNNING = 0
-    STOPPED = 1
-    FAILED = 2
-    CRASHED = 3
-    UNKNOWN = 4
-
-
 class BrokerType:
     """Base class for types we can instantiate from or render to the
     Python-level Broker data model.
@@ -367,6 +349,78 @@ class BrokerType:
         """Returns an instance of the type given Broker data. Raises TypeError when the
         given data doesn't match the type's expectations."""
         return None
+
+
+class BrokerEnumType(BrokerType, enum.Enum):
+    """A specialization of Broker-based enums to bridge Broker/Python.
+
+    This distinguishes the "flat" Python enums ("FOO") from the fully qualified
+    way they're rendered via Zeek ("Some::Module::FOO"). To enable a Python enum
+    to present the full qualification when sending into Broker, derivations
+    reimplement the module_scope() class method.
+    """
+    def to_broker(self):
+        # XXX figuring out the need to use broker.Data.from_py() and
+        # as_enum_value() when presenting an enum to Broker is pretty
+        # tricky. Would be great if we could simplify this.
+        scope = self.module_scope()
+        scope = scope + '::' if scope else ''
+        return broker.Data.from_py(scope + self.name).as_enum_value()
+
+    def to_json_data(self):
+        # A similar concern as above applies here, but the exact enum type will
+        # often be clear from context and so the un-scoped name alone may
+        # suffice.
+        return self.name
+
+    def __str__(self):
+        scope = self.module_scope()
+        scope = scope + '::' if scope else ''
+        return scope + self.name
+
+    @classmethod
+    def module_scope(cls):
+        # Reimplement this in derived classes to convey the Zeek-level enum
+        # scope. For example, for a Foo.BAR enum value, this should return the
+        # string "Foo".
+        return ''
+
+    @classmethod
+    def from_broker(cls, broker_data):
+        # The argument is a broker.Enum with a name property like Foo::VALUE, so
+        # grab the last part and look it up in this enum type:
+        try:
+            return cls[broker_data.name.split('::')[-1]]
+        except KeyError as err:
+            raise TypeError('unexpected enum value for {}: {}'.format(
+                cls.__name__, broker_data)) from err
+
+
+class ClusterRole(BrokerEnumType):
+    """Equivalent of Supervisor::ClusterRole enum in Zeek"""
+    NONE = 0
+    LOGGER = 1
+    MANAGER = 2
+    PROXY = 3
+    WORKER = 4
+
+    @classmethod
+    def module_scope(cls):
+        return 'Supervisor'
+
+
+class State(BrokerEnumType):
+    """Equivalent of ClusterController::Types::State enum in Zeek"""
+    PENDING = 0
+    RUNNING = 1
+    STOPPED = 2
+    FAILED = 3
+    CRASHED = 4
+    UNKNOWN = 5
+
+    @classmethod
+    def module_scope(cls):
+        return 'ClusterController::Types'
 
 
 class Option(BrokerType):
@@ -436,12 +490,8 @@ class Node(BrokerType):
 
         return (self.name, self.instance,
                 broker.Port(self.port, broker.Port.TCP),
-                # XXX enums are a bit tricky, per the below -- we should cover
-                # these in the Broker Python binding docs. (Same for None vs
-                # Broker's nil.)
-                broker.Data.from_py('Supervisor::' + self.role.name).as_enum_value(),
-                broker.Data.from_py('ClusterController::Types::' +
-                                    self.state.name.title()).as_enum_value(),
+                self.role.to_broker(),
+                self.state.to_broker(),
                 self.scripts,
                 self.options,
                 self.interface,
@@ -463,25 +513,29 @@ class Node(BrokerType):
 
         instance = get(str, 'instance')
         port = get(int, 'port')
-        role = get(str, 'role', 'type')
-        state = get(str, 'state') or 'RUNNING'
         interface = get(str, 'interface')
         cpu_affinity = get(int, 'cpu_affinity')
 
         # Validate the specified values
         if not instance:
             raise ValueError('node "{}" requires an instance'.format(name))
-        if role is None or role.upper() not in Role.__members__.keys():
-            raise ValueError('node "{}" role "{}" is invalid'.format(name, role))
         if port is None or port < 1 or port > 65535:
             raise ValueError('node "{}" port "{}" is invalid'.format(name, port))
-        if state is None or state.upper() not in State.__members__.keys():
-            raise ValueError('node "{}" state "{}" is invalid'.format(name, state))
 
-        return Node(name=name, instance=instance, port=port,
-                    role=Role.__members__.get(role.upper()),
-                    state=State.__members__.get(state.upper()),
-                    interface=interface, cpu_affinity=cpu_affinity)
+        try:
+            role_raw = get(str, 'role', 'type')
+            role = ClusterRole[role_raw.upper()]
+        except (AttributeError, KeyError) as err:
+            raise ValueError('node "{}" role "{}" is invalid'.format(name, role_raw)) from err
+
+        try:
+            state_raw = get(str, 'state') or 'RUNNING'
+            state = State[state_raw.upper()]
+        except (AttributeError, KeyError) as err:
+            raise ValueError('node "{}" state "{}" is invalid'.format(name, state_raw)) from err
+
+        return Node(name=name, instance=instance, port=port, role=role,
+                    state=state, interface=interface, cpu_affinity=cpu_affinity)
 
 
 class Configuration(BrokerType):
@@ -691,6 +745,8 @@ def json_dumps(obj):
             return str(obj)
         if isinstance(obj, broker.Port):
             return str(obj)
+        if isinstance(obj, BrokerEnumType):
+            return obj.to_json_data()
         raise TypeError('cannot serialize {} ({})'.format(type(obj), str(obj)))
 
     return json.dumps(obj, default=default, sort_keys=True)

--- a/zeek-client
+++ b/zeek-client
@@ -12,6 +12,17 @@ the idioms and primitives also used by the zkg package manager.
 # pylint: disable=invalid-name, missing-function-docstring, too-few-public-methods
 # pylint: disable=too-many-instance-attributes, too-many-arguments, no-self-use
 
+# Broker lessons learned:
+#
+# - When sending an event from Python results in an error message like the
+#   following on the Zeek side ...
+#
+#     warning: failed to convert remote event '<some event type>' arg #<n>,
+#         got vector, expected record
+#
+#   ... the reason is that some member of the structure in question (here,
+#   a record) could not be unserialized properly.
+
 import argparse
 import configparser
 import enum
@@ -57,6 +68,10 @@ except ImportError:
 
 
 class ClientConfig(configparser.ConfigParser):
+    """zeek-client configuration settings.
+
+    A specialized ConfigParser that hardwires defaults for select values.
+    """
     def __init__(self, config_file=ZC_CONFIG_FILE):
         super().__init__()
         self.read_dict({
@@ -188,7 +203,6 @@ class EventRegistry:
 
 class events:
     """A scope to define event types we understand. Could become a module."""
-
     # Any Zeek object/record gets represented as a tuple here.
 
     GetInstancesRequest = EventRegistry.make_event_class(
@@ -222,7 +236,6 @@ class events:
 
 class Controller:
     """A class representing our Broker connection to the Zeek cluster controller."""
-
     def __init__(self, controller_host, controller_port,
                  controller_topic=ZC_CONTROLLER_TOPIC):
         self.controller_host = controller_host
@@ -252,13 +265,14 @@ class Controller:
                 LOG.debug('peered with controller %s:%s', self.controller_host,
                           self.controller_port)
                 return True
-            else:
-                LOG.warning('broker endpoint status: %s', status)
+
+            LOG.warning('broker endpoint status: %s', status)
 
             if i < attempts - 1:
                 time.sleep(ZC_CONFIG.getfloat('client', 'connect_retry_delay_secs'))
 
-        print('error: could not connect to controller')
+        print('error: could not connect to controller {}:{}'.format(
+            self.controller_host, self.controller_port))
         return False
 
     def publish(self, event):
@@ -357,7 +371,6 @@ class BrokerType:
 
 class Option(BrokerType):
     """Equivalent of ClusterController::Types::Option."""
-
     def __init__(self, name, value):
         self.name = name
         self.value = value
@@ -368,7 +381,6 @@ class Option(BrokerType):
 
 class Instance(BrokerType):
     """Equivalent of ClusterController::Types::Instance."""
-
     def __init__(self, name, addr=None, port=None):
         self.name = name
         # This is a workaround until we've resolved addresses in instances
@@ -380,8 +392,9 @@ class Instance(BrokerType):
         try:
             name, addr, port = broker_data
             return Instance(name, addr, port)
-        except ValueError:
-            raise TypeError('unexpected Broker data for Instance object ({})'.format(broker_data))
+        except ValueError as err:
+            raise TypeError('unexpected Broker data for Instance object ({})'.format(
+                broker_data)) from err
 
     def to_broker(self):
         port = None
@@ -473,7 +486,6 @@ class Node(BrokerType):
 
 class Configuration(BrokerType):
     """Equivalent of ClusterController::Types::Configuration."""
-
     def __init__(self):
         self.id = make_uuid()
         self.instances = []
@@ -493,7 +505,6 @@ class Configuration(BrokerType):
 
 class Result(BrokerType):
     """Equivalent of ClusterController::Types::Result."""
-
     def __init__(self, reqid, instance, success=True, data=None, error=None, node=None):
         self.reqid = reqid
         self.instance = instance
@@ -544,7 +555,6 @@ def cmd_get_instances(controller, args): # pylint: disable=unused-argument
     json_data = sorted(json_data, key=lambda inst: inst['name'])
 
     print(json_dumps(json_data))
-
     return 0
 
 
@@ -602,7 +612,7 @@ def cmd_set_config(controller, args):
         # All keys for sections other than "instances" need to have a value.
         for key, val in parser.items(section):
             if val is None:
-                Log.error('Config item %s/%s needs a value', sect, key)
+                LOG.error('Config item %s/%s needs a value', section, key)
                 return 1
 
         # The other sections are data cluster nodes. Each section name
@@ -661,7 +671,6 @@ def cmd_test_timeout(controller, args):
     error = res.error if res.error else '(none)'
 
     print_error('response is {}, error string: {}'.format(outcome, error))
-
     return 0
 
 


### PR DESCRIPTION
This PR contains two main parts:

- It refactors the translation of Zeek's enums to/from Python `enum.Enum` objects. This is a bit tricky since Zeek renders enums into fully-scoped strings ("Foo.Bar.VAL_1") with no immediate equivalent to such scoping in Python. The PR adds a new class hierarchy branch for enums to make the rendering of enums to/from Broker more similar to that of other records.

- More importantly, it adds a `get-nodes` command to support the new corresponding functionality on the Zeek side. 

For a deployed configuration this might look as follows:
```
$ zeek-client get-nodes | jq .
{
  "instance-1": {
    "controller-swinetrek": {
      "cluster_role": null,
      "mgmt_role": "CONTROLLER",
      "pid": 2137201,
      "state": "RUNNING"
    },
    "instance-1": {
      "cluster_role": null,
      "mgmt_role": "AGENT",
      "pid": 2137200,
      "state": "RUNNING"
    },
    "logger-01": {
      "cluster_role": "LOGGER",
      "mgmt_role": null,
      "pid": 2137288,
      "state": "RUNNING"
    },
    "manager": {
      "cluster_role": "MANAGER",
      "mgmt_role": null,
      "pid": 2137289,
      "state": "RUNNING"
    },
    "worker-01": {
      "cluster_role": "WORKER",
      "mgmt_role": null,
      "pid": 2137291,
      "state": "RUNNING"
    },
    "worker-02": {
      "cluster_role": "WORKER",
      "mgmt_role": null,
      "pid": 2137290,
      "state": "RUNNING"
    }
  }
}
```