### PR TITLE
Support argcomplete when available

### DIFF
--- a/zeek-client
+++ b/zeek-client
@@ -9,6 +9,9 @@ Work on this client is currently in progress and maturing over the course of
 the Zeek 4.x series. Feedback is welcome. This implementation adopts many of
 the idioms and primitives also used by the zkg package manager.
 """
+# https://pypi.org/project/argcomplete/#global-completion
+# PYTHON_ARGCOMPLETE_OK
+
 # pylint: disable=invalid-name, missing-function-docstring, too-few-public-methods
 # pylint: disable=too-many-instance-attributes, too-many-arguments, no-self-use
 
@@ -35,6 +38,13 @@ import sys
 import time
 import traceback
 import uuid
+
+try:
+    # Argcomplete provides command-line completion for users of argparse.
+    # We support it if available, but don't complain when it isn't.
+    import argcomplete # pylint: disable=import-error
+except ImportError:
+    pass
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
@@ -1006,6 +1016,9 @@ def create_parser():
     sub_parser.set_defaults(run_cmd=cmd_test_timeout)
     sub_parser.add_argument('--with-state', action='store_true',
                             help='Make request stateful in the controller.')
+
+    if 'argcomplete' in sys.modules:
+        argcomplete.autocomplete(parser)
 
     return parser
 


### PR DESCRIPTION
Just like in zeek-script: run the built-up argparse parser through argcomplete to provide command-line completion.