### PR TITLE
Support new `set-config` response format

### DIFF
--- a/zeek-client
+++ b/zeek-client
@@ -1253,15 +1253,29 @@ def cmd_set_config(controller, args):
         LOG.error('received unexpected event: %s', resp)
         return 1
 
+    json_data = {}
     retval = 0
 
     for broker_data in resp.results:
         res = Result.from_broker(broker_data)
+
         if not res.success:
-            msg = ': ' + res.error if res.error else ''
-            LOG.error('instance %s failure%s', res.instance, msg)
             retval = 1
 
+        # If the result record doesn't mention a node, it's the response of an
+        # agent that had no nodes to launch (but possibly dropped existing ones
+        # as part of this request). We adopt its error state, but don't render
+        # any output.
+        if res.node is None:
+            continue
+
+        json_data[res.node] = {
+            'success': res.success,
+            'instance': res.instance,
+        }
+
+
+    print(json_dumps(json_data))
     return retval
 
 

--- a/zeek-client
+++ b/zeek-client
@@ -1010,6 +1010,18 @@ class Result(BrokerType):
     def from_broker(cls, broker_data):
         return Result(*broker_data)
 
+
+class NodeOutputs(BrokerType):
+    """Equivalent of Management::NodeOutputs."""
+    def __init__(self, stdout, stderr):
+        self.stdout = stdout
+        self.stderr = stderr
+
+    @classmethod
+    def from_broker(cls, broker_data):
+        return NodeOutputs(*broker_data)
+
+
 # Command handlers
 
 def cmd_get_config(controller, args):
@@ -1273,6 +1285,13 @@ def cmd_set_config(controller, args):
             'success': res.success,
             'instance': res.instance,
         }
+
+        # If launching this node failed, we should have a NodeOutputs record as
+        # data member in the result record.
+        if res.data:
+            node_outputs = NodeOutputs.from_broker(res.data)
+            json_data[res.node]['stdout'] = node_outputs.stdout
+            json_data[res.node]['stderr'] = node_outputs.stderr
 
 
     print(json_dumps(json_data))


### PR DESCRIPTION
Companion PR to zeek/zeek#2139, rendering the `set-config` result records into JSON.