### PR TITLE
Minor updates to client configuration and parsing cluster configs from .ini

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+"""This verifies zeek-client invocations."""
+import os
+import subprocess
+import sys
+import unittest
+
+TESTS = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.normpath(os.path.join(TESTS, '..'))
+
+# Prepend this folder so we can load our mocks
+sys.path.insert(0, TESTS)
+
+# This is the Broker mock, not the real one
+import broker
+
+# Prepend the tree's root folder to the module searchpath so we find zeekclient
+# via it. This allows tests to run without package installation.
+sys.path.insert(0, ROOT)
+
+
+class TestCli(unittest.TestCase):
+    def setUp(self):
+        # Set up an environment in which subprocesses pick up our stub Broker fist:
+        self.env = os.environ.copy()
+        self.env['PYTHONPATH'] = os.pathsep.join(sys.path)
+
+    def test_help(self):
+        cproc = subprocess.run([os.path.join(ROOT, 'zeek-client'), '--help'],
+                               env=self.env, capture_output=True)
+        self.assertEqual(cproc.returncode, 0)
+
+    def test_show_settings(self):
+        env = os.environ.copy()
+        env['PYTHONPATH'] = os.pathsep.join(sys.path)
+        cproc = subprocess.run([os.path.join(ROOT, 'zeek-client'), 'show-settings'],
+                               env=self.env, capture_output=True)
+        self.assertEqual(cproc.returncode, 0)
+
+
+def test():
+    """Entry point for testing this module.
+
+    Returns True if successful, False otherwise.
+    """
+    res = unittest.main(sys.modules[__name__], verbosity=0, exit=False)
+    # This is how unittest.main() implements the exit code itself:
+    return res.result.wasSuccessful()
+
+if __name__ == '__main__':
+    sys.exit(not test())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,33 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.config.getint('client', 'request_timeout_secs'), 42)
         self.assertEqual(self.config.get('server', 'FOO'), '1 2 3')
 
+    def test_update_from_args_controller_host(self):
+        parser = zeekclient.cli.create_parser()
+        args = parser.parse_args(['--controller', 'foo'])
+        self.config.update_from_args(args)
+        self.assertEqual(self.config.get('controller', 'host'), 'foo')
+        self.assertEqual(self.config.getint('controller', 'port'), 2150)
+
+        parser = zeekclient.cli.create_parser()
+        args = parser.parse_args(['--controller', 'foo:'])
+        self.config.update_from_args(args)
+        self.assertEqual(self.config.get('controller', 'host'), 'foo')
+        self.assertEqual(self.config.getint('controller', 'port'), 2150)
+
+    def test_update_from_args_controller_port(self):
+        parser = zeekclient.cli.create_parser()
+        args = parser.parse_args(['--controller', ':2222'])
+        self.config.update_from_args(args)
+        self.assertEqual(self.config.get('controller', 'host'), '127.0.0.1')
+        self.assertEqual(self.config.getint('controller', 'port'), 2222)
+
+    def test_update_from_args_controller_hostport(self):
+        parser = zeekclient.cli.create_parser()
+        args = parser.parse_args(['--controller', 'foo:2222'])
+        self.config.update_from_args(args)
+        self.assertEqual(self.config.get('controller', 'host'), 'foo')
+        self.assertEqual(self.config.getint('controller', 'port'), 2222)
+
 
 def test():
     """Entry point for testing this module.

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -361,6 +361,47 @@ role = manager
             self.logbuf.getvalue(),
             'error: invalid node "manager" configuration: port 70000 outside valid range')
 
+    def test_config_missing_instance_section(self):
+        ini_input = """
+[manager]
+instance = agent
+role = manager
+
+[logger]
+instance = agent2
+role = logger
+
+[worker]
+instance = agent
+role = worker
+"""
+        ini_expected = """
+[instances]
+agent
+agent2
+
+[logger]
+instance = agent2
+role = LOGGER
+
+[manager]
+instance = agent
+role = MANAGER
+
+[worker]
+instance = agent
+role = WORKER
+"""
+        cfp = self.parserFromString(ini_input)
+        config = zeekclient.Configuration.from_config_parser(cfp)
+        self.assertTrue(config is not None)
+
+        cfp = config.to_config_parser()
+        with io.StringIO() as buf:
+            cfp.write(buf)
+            self.assertEqualStripped(buf.getvalue(), ini_expected)
+
+
 def test():
     """Entry point for testing this module.
 

--- a/zeek-client
+++ b/zeek-client
@@ -70,26 +70,10 @@ def main():
         zeekclient.logs.configure(args.verbose, zeekclient.CONFIG.getboolean(
             'client', 'rich_logging_format'))
 
-    controller_parts = args.controller.split(':', 1)
+    controller = zeekclient.Controller(
+        zeekclient.CONFIG.get('controller', 'host'),
+        zeekclient.CONFIG.getint('controller', 'port'))
 
-    if len(controller_parts) != 2:
-        # Allow just a host, falling back to default port
-        controller_parts = [controller_parts[0], zeekclient.CONTROLLER_PORT]
-    elif not controller_parts[0]:
-        # Allow just a port (as ":<port>"), falling back to default host.
-        controller_parts = [zeekclient.CONTROLLER_HOST, controller_parts[1]]
-
-    controller_host = controller_parts[0]
-
-    try:
-        controller_port = int(controller_parts[1])
-        if controller_port < 1 or controller_port > 65535:
-            raise ValueError
-    except ValueError:
-        zeekclient.LOG.error('controller port number outside valid range')
-        return 1
-
-    controller = zeekclient.Controller(controller_host, controller_port)
     if not controller.connect():
         return 1
 

--- a/zeek-client
+++ b/zeek-client
@@ -70,19 +70,12 @@ def main():
         zeekclient.logs.configure(args.verbose, zeekclient.CONFIG.getboolean(
             'client', 'rich_logging_format'))
 
-    controller = zeekclient.Controller(
-        zeekclient.CONFIG.get('controller', 'host'),
-        zeekclient.CONFIG.getint('controller', 'port'))
-
-    if not controller.connect():
-        return 1
-
     if not args.command:
         zeekclient.LOG.error('please provide a command to execute.')
         return 1
 
     try:
-        return args.run_cmd(controller, args)
+        return args.run_cmd(args)
     except KeyboardInterrupt:
         return 0
 

--- a/zeek-client
+++ b/zeek-client
@@ -67,8 +67,9 @@ def main():
 
     # Establish logging as per requested verbosity and formatting
     if not args.quiet:
-        zeekclient.logs.configure(args.verbose, zeekclient.CONFIG.getboolean(
-            'client', 'rich_logging_format'))
+        zeekclient.logs.configure(
+            zeekclient.CONFIG.getint('client', 'verbosity'),
+            zeekclient.CONFIG.getboolean('client', 'rich_logging_format'))
 
     if not args.command:
         zeekclient.LOG.error('please provide a command to execute.')

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -11,6 +11,8 @@ import broker
 
 from .config import CONFIG
 
+from .controller import Controller
+
 from .consts import (
     CONFIG_FILE
 )
@@ -64,6 +66,16 @@ def json_dumps(obj):
 
     indent = 2 if CONFIG.getboolean('client', 'pretty_json') else None
     return json.dumps(obj, default=default, sort_keys=True, indent=indent)
+
+
+def create_controller():
+    controller = Controller(CONFIG.get('controller', 'host'),
+                            CONFIG.getint('controller', 'port'))
+
+    if not controller.connect():
+        return None
+
+    return controller
 
 
 def create_parser():
@@ -153,7 +165,11 @@ def create_parser():
     return parser
 
 
-def cmd_get_config(controller, args):
+def cmd_get_config(args):
+    controller = create_controller()
+    if controller is None:
+        return 1
+
     controller.publish(GetConfigurationRequest(make_uuid()))
     resp, msg = controller.receive()
 
@@ -188,7 +204,11 @@ def cmd_get_config(controller, args):
     return 0
 
 
-def cmd_get_id_value(controller, args):
+def cmd_get_id_value(args):
+    controller = create_controller()
+    if controller is None:
+        return 1
+
     controller.publish(GetIdValueRequest(make_uuid(), args.id, set(args.nodes)))
     resp, msg = controller.receive()
 
@@ -241,7 +261,11 @@ def cmd_get_id_value(controller, args):
     return 0 if len(json_data['errors']) == 0 else 1
 
 
-def cmd_get_instances(controller, args): # pylint: disable=unused-argument
+def cmd_get_instances(_args):
+    controller = create_controller()
+    if controller is None:
+        return 1
+
     controller.publish(GetInstancesRequest(make_uuid()))
     resp, msg = controller.receive()
 
@@ -280,7 +304,11 @@ def cmd_get_instances(controller, args): # pylint: disable=unused-argument
     return 0
 
 
-def cmd_get_nodes(controller, _args):
+def cmd_get_nodes(_args):
+    controller = create_controller()
+    if controller is None:
+        return 1
+
     controller.publish(GetNodesRequest(make_uuid()))
     resp, msg = controller.receive()
 
@@ -344,7 +372,11 @@ def cmd_get_nodes(controller, _args):
     return 0 if len(json_data['errors']) == 0 else 1
 
 
-def cmd_monitor(controller, args): # pylint: disable=unused-argument
+def cmd_monitor(_args):
+    controller = create_controller()
+    if controller is None:
+        return 1
+
     while True:
         resp, msg = controller.receive(None)
 
@@ -356,7 +388,7 @@ def cmd_monitor(controller, args): # pylint: disable=unused-argument
     return 0
 
 
-def cmd_set_config(controller, args):
+def cmd_set_config(args):
     if not args.config or (args.config != '-' and not os.path.isfile(args.config)):
         LOG.error('please provide a cluster configuration file.')
         return 1
@@ -381,6 +413,10 @@ def cmd_set_config(controller, args):
 
     if config is None:
         LOG.error('configuration has errors, not deploying')
+        return 1
+
+    controller = create_controller()
+    if controller is None:
         return 1
 
     controller.publish(SetConfigurationRequest(make_uuid(), config.to_broker()))
@@ -428,12 +464,16 @@ def cmd_set_config(controller, args):
     return retval
 
 
-def cmd_show_settings(_controller, _args):
+def cmd_show_settings(_args):
     CONFIG.write(sys.stdout)
     return 0
 
 
-def cmd_test_timeout(controller, args):
+def cmd_test_timeout(args):
+    controller = create_controller()
+    if controller is None:
+        return 1
+
     controller.publish(TestTimeoutRequest(make_uuid(), args.with_state))
     resp, msg = controller.receive()
 

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -12,8 +12,7 @@ import broker
 from .config import CONFIG
 
 from .consts import (
-    CONFIG_FILE,
-    CONTROLLER
+    CONFIG_FILE
 )
 
 from .events import (
@@ -77,11 +76,14 @@ def create_parser():
         '    ZEEK_CLIENT_CONFIG_SETTINGS:  '
         'Same as a space-separated series of `--set` arguments, but lower precedence.\n')
 
+    controller = '{}:{}'.format(CONFIG.get('controller', 'host'),
+                                CONFIG.get('controller', 'port'))
+
     parser.add_argument('-c', '--configfile', metavar='FILE', default=CONFIG_FILE,
                         help='Path to zeek-client config file. (Default: {})'.format(CONFIG_FILE))
-    parser.add_argument('--controller', metavar='HOST:PORT', default=CONTROLLER,
+    parser.add_argument('--controller', metavar='HOST:PORT',
                         help='Address and port of the controller, either of '
-                        'which may be omitted (default: {})'.format(CONTROLLER))
+                        'which may be omitted (default: {})'.format(controller))
     arg = parser.add_argument('--set', metavar='SECTION.KEY=VAL', action='append', default=[],
                               help='Adjust a configuration setting. Can use repeatedly. '
                               'See show-settings.')

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -106,7 +106,7 @@ def create_parser():
     verbosity_group = parser.add_mutually_exclusive_group()
     verbosity_group.add_argument('--quiet', '-q', action='store_true',
                                  help='Suppress informational output to stderr.')
-    verbosity_group.add_argument('--verbose', '-v', action='count', default=0,
+    verbosity_group.add_argument('--verbose', '-v', action='count',
                                  help='Increase informational output to stderr. '
                                  'Repeat for more output (e.g. -vvv).')
 

--- a/zeekclient/config.py
+++ b/zeekclient/config.py
@@ -48,6 +48,14 @@ class Config(configparser.ConfigParser):
 
                 # Whether we pretty-print JSON output by default.
                 'pretty_json': True,
+
+                # Default output verbosity level:
+                #   0   permits errors
+                #   1   also warnings
+                #   2   also informational messages
+                #   3   also debug messages
+                #   4+  no additional effect
+                'verbosity': 0,
             },
             'controller': {
                 # Default host name/address where we contact the controller.
@@ -90,6 +98,10 @@ class Config(configparser.ConfigParser):
             else:
                 self.set('controller', 'host', host_port[0])
                 self.set('controller', 'port', host_port[1])
+
+        # --verbose/-v/-vvv etc set a numeric verbosity level:
+        if args.verbose:
+            self.set('client', 'verbosity', str(args.verbose))
 
     def apply(self, item):
         """This is equivalent to set(), but works via a single <section.key>=<val> string."""

--- a/zeekclient/config.py
+++ b/zeekclient/config.py
@@ -40,7 +40,7 @@ class Config(configparser.ConfigParser):
                 # How often to attempt peerings within Controller.connect():
                 'connect_attempts': 4,
 
-                # Delay between our on connect attempts.
+                # Delay between our connection attempts.
                 'connect_retry_delay_secs': 0.25,
 
                 # The way zeek-client reports informational messages on stderr
@@ -48,6 +48,13 @@ class Config(configparser.ConfigParser):
 
                 # Whether we pretty-print JSON output by default.
                 'pretty_json': True,
+            },
+            'controller': {
+                # Default host name/address where we contact the controller.
+                'host': '127.0.0.1',
+
+                # Default port of the controller.
+                'port': 2150,
             },
         })
 
@@ -69,6 +76,20 @@ class Config(configparser.ConfigParser):
             except ValueError:
                 LOG.error('config item "%s" invalid. Please use '
                           '<section.key>=<val>.', item)
+
+        # The `--controller` argument is a shortcut for two `--set` arguments that
+        # set controller host and port, so update these manually:
+        if args.controller:
+            host_port = args.controller.split(':', 1)
+            if len(host_port) != 2 or not host_port[1]:
+                # It's just a hostname
+                self.set('controller', 'host', host_port[0])
+            elif not host_port[0]:
+                # It's just a port (as ":<port>")
+                self.set('controller', 'port', host_port[1])
+            else:
+                self.set('controller', 'host', host_port[0])
+                self.set('controller', 'port', host_port[1])
 
     def apply(self, item):
         """This is equivalent to set(), but works via a single <section.key>=<val> string."""

--- a/zeekclient/consts.py
+++ b/zeekclient/consts.py
@@ -1,14 +1,5 @@
 import os
 
-# Default address for connecting to the Zeek cluster controller
-CONTROLLER_HOST = '127.0.0.1'
-
-# The controller's default port
-CONTROLLER_PORT = '2150'
-
-# Controller host and port, combined
-CONTROLLER = CONTROLLER_HOST + ':' + CONTROLLER_PORT
-
 # The Broker topic prefix for communicating with the controller
 CONTROLLER_TOPIC = 'zeek/management/controller'
 

--- a/zeekclient/controller.py
+++ b/zeekclient/controller.py
@@ -26,6 +26,11 @@ class Controller:
         self.poll.register(self.ssub.fd())
 
     def connect(self):
+        if self.controller_port < 1 or self.controller_port > 65535:
+            LOG.error('controller port number {} outside valid range'.format(
+                self.controller_port))
+            return False
+
         # We add retries around Broker's peering because some problems don't
         # fall under its built-in retry umbrella. Our explicit retries simplify
         # testing setups, where they mask the bootstrapping of the services

--- a/zeekclient/logs.py
+++ b/zeekclient/logs.py
@@ -5,7 +5,7 @@ LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 
 
-def configure(verbosity=1, rich_logging=False, stream=None):
+def configure(verbosity=0, rich_logging=False, stream=None):
     """Configures logging.
 
     Args:

--- a/zeekclient/types.py
+++ b/zeekclient/types.py
@@ -523,6 +523,17 @@ class Configuration(BrokerType, ConfigParserMixin):
                 LOG.error('invalid node "%s" configuration: %s', section, err)
                 return None
 
+        # When the configuration has no "instances" section, then any instance
+        # names given in node sections imply corresponding instances whose
+        # agents connect to the controller. That is, the instances section is
+        # just a redundant listing of the instance names and we can synthesize
+        # it:
+        if 'instances' not in cfp.sections():
+            names = set()
+            for node in config.nodes:
+                names.add(node.instance)
+            config.instances = sorted([Instance(name) for name in names])
+
         return config
 
     def to_config_parser(self, cfp=None):


### PR DESCRIPTION
These are client-only changes that make two aspects of its configuration that so far could only happen via command line flags handled uniformly: the controller to connect to, and the verbosity level.

This also permits simpler cluster config .ini files: in configs where agents connect to the controller, it will often be the case that the `instances` section is simply a list of instance names that is already expressed via the names of instances that nodes declare themselves running on. You can now omit the instance section in that case, allowing nodes to imply the instances list. 