### PR TITLE
Separate `set-config` into `stage-config` and `deploy`, add `deploy-config` to combine both

### DIFF
--- a/tests/broker.py
+++ b/tests/broker.py
@@ -48,6 +48,9 @@ class Subscriber:
         self.topic = ""
         self.data = ()
 
+    def available(self):
+        return True
+
     def fd(self):
         return 0
 
@@ -63,6 +66,9 @@ class StatusSubscriber:
     def __init__(self):
         self.fd_val = 0
         self.status = Status()
+
+    def available(self):
+        return True
 
     def fd(self):
         return self.fd_val

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,8 +33,9 @@ class TestConfig(unittest.TestCase):
         self.config = zeekclient.Config()
 
     def test_basics(self):
+        # One of each type:
         self.assertEqual(self.config.getint('client', 'request_timeout_secs'), 20)
-        self.assertEqual(self.config.getfloat('client', 'connect_retry_delay_secs'), 0.25)
+        self.assertEqual(self.config.getfloat('client', 'peering_status_retry_delay_secs'), 0.5)
         self.assertEqual(self.config.getboolean('client', 'rich_logging_format'), False)
 
     def test_update_from_file(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -76,7 +76,7 @@ class TestRendering(unittest.TestCase):
         controller = zeekclient.controller.Controller('127.0.0.1', 2150)
         event = zeekclient.Registry.make_event(
             ('Management::Controller::API::get_configuration_request',
-             zeekclient.utils.make_uuid()))
+             zeekclient.utils.make_uuid(), True))
 
         controller.publish(event)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -61,16 +61,20 @@ class TestRendering(unittest.TestCase):
         self.assertTrue(controller.connect())
         self.assertEqualStripped(
             self.logbuf.getvalue(),
+            'info: connecting to controller 127.0.0.1:2150\n' +
             'info: peered with controller 127.0.0.1:2150')
 
     def test_connect_fails(self):
         controller = zeekclient.controller.Controller('127.0.0.1', 2150)
         # Ensure the connects keep failing:
         controller.ssub.status = broker.Status(broker.SC.Unspecified)
+        # Dial down attempts to make this fast:
+        zeekclient.CONFIG.set('client', 'peering_status_attempts', '2')
         self.assertFalse(controller.connect())
         self.assertEqualStripped(
             self.logbuf.getvalue(),
-            'error: could not connect to controller 127.0.0.1:2150')
+            'info: connecting to controller 127.0.0.1:2150\n' +
+            'error: could not peer with controller 127.0.0.1:2150')
 
     def test_publish(self):
         controller = zeekclient.controller.Controller('127.0.0.1', 2150)

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -185,7 +185,7 @@ def cmd_get_config(args):
 
     if not res.success:
         msg = res.error if res.error else 'no reason given'
-        LOG.error('response indicates failure: %s', msg)
+        LOG.error(msg)
         return 1
 
     if not res.data:
@@ -281,7 +281,7 @@ def cmd_get_instances(_args):
 
     if not res.success:
         msg = res.error if res.error else 'no reason given'
-        LOG.error('response indicates failure: %s', msg)
+        LOG.error(msg)
         return 1
 
     if res.data is None:

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -124,6 +124,12 @@ def create_parser():
                             help='Output file for the configuration, default stdout')
     sub_parser.add_argument('--as-json', action='store_true',
                             help='Report in JSON instead of INI-style config file')
+    get_config_group = sub_parser.add_mutually_exclusive_group()
+    get_config_group.add_argument('--deployed', action='store_true',
+                                  dest='deployed', default=False,
+                                  help='Return deployed configuration')
+    get_config_group.add_argument('--staged', action='store_false', dest='deployed',
+                                  help='Return staged configuration (default)')
 
     sub_parser = command_parser.add_parser(
         'get-id-value', help='Show the value of a given identifier in Zeek cluster nodes.')
@@ -170,7 +176,7 @@ def cmd_get_config(args):
     if controller is None:
         return 1
 
-    controller.publish(GetConfigurationRequest(make_uuid()))
+    controller.publish(GetConfigurationRequest(make_uuid(), args.deployed))
     resp, msg = controller.receive()
 
     if resp is None:

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -28,8 +28,8 @@ from .events import (
     GetInstancesResponse,
     GetNodesRequest,
     GetNodesResponse,
-    SetConfigurationRequest,
-    SetConfigurationResponse,
+    StageConfigurationRequest,
+    StageConfigurationResponse,
     TestTimeoutRequest,
     TestTimeoutResponse
 )
@@ -165,8 +165,8 @@ def create_parser():
     sub_parser.set_defaults(run_cmd=cmd_monitor)
 
     sub_parser = command_parser.add_parser(
-        'set-config', help='Upload a cluster configuration.')
-    sub_parser.set_defaults(run_cmd=cmd_set_config)
+        'stage-config', help='Upload a cluster configuration for later deployment.')
+    sub_parser.set_defaults(run_cmd=cmd_stage_config)
     sub_parser.add_argument('config', metavar='FILE',
                             help='Cluster configuration file, "-" for stdin')
 
@@ -480,8 +480,8 @@ def cmd_monitor(_args):
     return 0
 
 
-def cmd_set_config_impl(args):
-    """Internals of cmd_set_config() to enable chaining with other commands.
+def cmd_stage_config_impl(args):
+    """Internals of cmd_stage_config() to enable chaining with other commands.
 
     Returns a tuple of exit code and any JSON data to show to the user/caller.
     """
@@ -515,14 +515,14 @@ def cmd_set_config_impl(args):
     if controller is None:
         return 1, None
 
-    controller.publish(SetConfigurationRequest(make_uuid(), config.to_broker()))
+    controller.publish(StageConfigurationRequest(make_uuid(), config.to_broker()))
     resp, msg = controller.receive()
 
     if resp is None:
         LOG.error('no response received: %s', msg)
         return 1, None
 
-    if not isinstance(resp, SetConfigurationResponse):
+    if not isinstance(resp, StageConfigurationResponse):
         LOG.error('received unexpected event: %s', resp)
         return 1, None
 
@@ -550,8 +550,8 @@ def cmd_set_config_impl(args):
     return retval, json_data
 
 
-def cmd_set_config(args):
-    ret, json_data = cmd_set_config_impl(args)
+def cmd_stage_config(args):
+    ret, json_data = cmd_stage_config_impl(args)
 
     if json_data:
         print(json_dumps(json_data))
@@ -560,7 +560,7 @@ def cmd_set_config(args):
 
 
 def cmd_deploy_config(args):
-    ret, json_data = cmd_set_config_impl(args)
+    ret, json_data = cmd_stage_config_impl(args)
 
     if ret != 0:
         if json_data:

--- a/zeekclient/config.py
+++ b/zeekclient/config.py
@@ -32,16 +32,20 @@ class Config(configparser.ConfigParser):
                 # events can fire & propagate in Zeek before we give up here.
                 'request_timeout_secs': 20,
 
-                # How long Broker's endpoint.peer() should wait until it retries
-                # a peering. Its default is 10 seconds; we dial that down
-                # because we retry anyway, per the next setting. 0 disables.
-                'connect_peer_retry_secs': 1,
+                # How long the client's Broker's endpoint should wait internally
+                # until it retries a peering upon connection or when the
+                # connection goes away. Its default is 10 seconds; we dial that
+                # down to be more interactive.
+                'peer_retry_secs': 1,
 
-                # How often to attempt peerings within Controller.connect():
-                'connect_attempts': 4,
+                # Successful peering requires the client's Broker status
+                # subscriber to observe a PeerAdded update, which may or may not
+                # arrive after connection establishment. This is the number of
+                # times we check for status updates:
+                'peering_status_attempts': 10,
 
-                # Delay between our connection attempts.
-                'connect_retry_delay_secs': 0.25,
+                # How long to wait between status update checks.
+                'peering_status_retry_delay_secs': 0.5,
 
                 # The way zeek-client reports informational messages on stderr
                 'rich_logging_format': False,

--- a/zeekclient/events.py
+++ b/zeekclient/events.py
@@ -150,12 +150,12 @@ GetNodesResponse = Registry.make_event_class(
     'Management::Controller::API::get_nodes_response',
     ('reqid', 'results'), (str, tuple))
 
-SetConfigurationRequest = Registry.make_event_class(
-    'Management::Controller::API::set_configuration_request',
+StageConfigurationRequest = Registry.make_event_class(
+    'Management::Controller::API::stage_configuration_request',
     ('reqid', 'config'), (str, tuple))
 
-SetConfigurationResponse = Registry.make_event_class(
-    'Management::Controller::API::set_configuration_response',
+StageConfigurationResponse = Registry.make_event_class(
+    'Management::Controller::API::stage_configuration_response',
     ('reqid', 'results'), (str, tuple))
 
 TestNoopRequest = Registry.make_event_class(

--- a/zeekclient/events.py
+++ b/zeekclient/events.py
@@ -112,7 +112,7 @@ class Registry:
 
 GetConfigurationRequest = Registry.make_event_class(
     'Management::Controller::API::get_configuration_request',
-    ('reqid',), (str,))
+    ('reqid', 'deployed'), (str, bool))
 
 GetConfigurationResponse = Registry.make_event_class(
     'Management::Controller::API::get_configuration_response',

--- a/zeekclient/events.py
+++ b/zeekclient/events.py
@@ -110,6 +110,14 @@ class Registry:
 # Any Zeek object/record that's an event argument gets represented as a
 # tuple below, reflecting Broker's representation thereof.
 
+DeployRequest = Registry.make_event_class(
+    'Management::Controller::API::deploy_request',
+    ('requid',), (str,))
+
+DeployResponse = Registry.make_event_class(
+    'Management::Controller::API::deploy_response',
+    ('reqid', 'results'), (str, tuple))
+
 GetConfigurationRequest = Registry.make_event_class(
     'Management::Controller::API::get_configuration_request',
     ('reqid', 'deployed'), (str, bool))

--- a/zeekclient/types.py
+++ b/zeekclient/types.py
@@ -589,10 +589,10 @@ class NodeStatus(BrokerType):
 
 class Result(BrokerType):
     """Equivalent of Management::Result."""
-    def __init__(self, reqid, instance, success=True, data=None, error=None, node=None):
+    def __init__(self, reqid, success=True, instance=None, data=None, error=None, node=None):
         self.reqid = reqid
-        self.instance = instance
         self.success = success
+        self.instance = instance
         self.data = data
         self.error = error
         self.node = node
@@ -601,10 +601,15 @@ class Result(BrokerType):
         """Support sorting. Sort first by instance name the result comes from, second by
         the node name if present.
         """
-        if self.instance < other.instance:
-            return True
-        if self.instance > other.instance:
+        if self.instance is None and other.instance is not None:
             return False
+        if self.instance is not None and other.instance is None:
+            return True
+        if self.instance is not None and other.instance is not None:
+            if self.instance < other.instance:
+                return True
+            if self.instance > other.instance:
+                return False
 
         # Be more specific if we have a node name -- we can use it to sort when
         # two results come from the same instance.


### PR DESCRIPTION
This is the companion PR to zeek/zeek#2197. Also contains a rework of `Controller.connect()`, which didn't need the loops around the peering, but did need to timeout the `get()` on the status subscriber.