### PR TITLE
Add `restart` command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ configure_file(
 install(DIRECTORY DESTINATION bin)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/zeek-client DESTINATION bin)
 
-# Install the Python module tree
+# Install the Python module tree. Use a pattern match to avoid installing any
+# .pyc or __pycache__ files that might reside in the directory due to local
+# unit-testing.
 install(DIRECTORY DESTINATION ${PY_MOD_INSTALL_DIR})
-install(DIRECTORY zeekclient DESTINATION ${PY_MOD_INSTALL_DIR})
+install(DIRECTORY zeekclient DESTINATION ${PY_MOD_INSTALL_DIR}
+    FILES_MATCHING PATTERN "zeekclient/*.py"
+    PATTERN "__pycache__" EXCLUDE)
 
 # Install the constants file with updated content:
 configure_file(

--- a/zeekclient/events.py
+++ b/zeekclient/events.py
@@ -150,6 +150,14 @@ GetNodesResponse = Registry.make_event_class(
     'Management::Controller::API::get_nodes_response',
     ('reqid', 'results'), (str, tuple))
 
+RestartRequest = Registry.make_event_class(
+    'Management::Controller::API::restart_request',
+    ('reqid', 'nodes'), (str, set))
+
+RestartResponse = Registry.make_event_class(
+    'Management::Controller::API::restart_response',
+    ('reqid', 'results'), (str, tuple))
+
 StageConfigurationRequest = Registry.make_event_class(
     'Management::Controller::API::stage_configuration_request',
     ('reqid', 'config'), (str, tuple))


### PR DESCRIPTION
This adds a command to restart all or specific Zeek cluster nodes in the current deployment. Also includes a cmake tweak to ensure we only install the .py files in the `zeekclient` directory, not any .pyc and related ones that running unit tests might have created.

Companion PR to zeek/zeek#2202. 