### PR TITLE
Simplify configs for single-host scenarios

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, The Zeek Project through the International Computer Science Institute.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,131 @@
 # The Zeek Cluster Management Client
 
-This is an experimental version of the future client application for managing
-Zeek clusters. `zeek-client` connects to Zeek's _cluster controller_, a Zeek
-instance that exists in every cluster. The controller in turn is connected to the
-cluster's _instances_, physical machines each running an _agent_ that maintains
-the _data nodes_ composing a typical Zeek cluster (with manager, workers,
-proxies, and loggers).
+[![Unit tests](https://github.com/zeek/zeek-client/actions/workflows/test.yml/badge.svg)](https://github.com/zeek/zeek-client/actions/workflows/test.yml)
+
+This is an experimental command-line client for interacting with Zeek's
+[Management framework](https://docs.zeek.org/en/master/frameworks/management.html).
+Built in Python and using Broker's [Python bindings](https://docs.zeek.org/projects/broker/en/current/python.html), it
+connects to a cluster controller to execute management tasks. Here's what it looks like:
+
+```console
+$ zeek-client --help
+usage: zeek-client [-h] [-c FILE] [--controller HOST:PORT] [--set SECTION.KEY=VAL] [--quiet | --verbose]
+                   [--version]
+                   {deploy,deploy-config,get-config,get-id-value,get-instances,get-nodes,monitor,restart,stage-config,show-settings,test-timeout}
+                   ...
+
+A Zeek management client
+
+options:
+  -h, --help            show this help message and exit
+  -c FILE, --configfile FILE
+                        Path to zeek-client config file. (Default: /home/christian/inst/opt/zeek/etc/zeek-
+                        client.cfg)
+  --controller HOST:PORT
+                        Address and port of the controller, either of which may be omitted (default:
+                        127.0.0.1:2150)
+  --set SECTION.KEY=VAL
+                        Adjust a configuration setting. Can use repeatedly. See show-settings.
+  --quiet, -q           Suppress informational output to stderr.
+  --verbose, -v         Increase informational output to stderr. Repeat for more output (e.g. -vvv).
+  --version             Show version number and exit.
+
+commands:
+  {deploy,deploy-config,get-config,get-id-value,get-instances,get-nodes,monitor,restart,stage-config,show-settings,test-timeout}
+                        See `zeek-client <command> -h` for per-command usage info.
+    deploy              Deploy a staged cluster configuration.
+    deploy-config       Upload a cluster configuration and deploy it.
+    get-config          Retrieve staged or deployed cluster configuration.
+    get-id-value        Show the value of a given identifier in Zeek cluster nodes.
+    get-instances       Show instances connected to the controller.
+    get-nodes           Show active Zeek nodes at each instance.
+    monitor             For troubleshooting: do nothing, just report events.
+    restart             Restart cluster nodes.
+    stage-config        Upload a cluster configuration for later deployment.
+    show-settings       Show zeek-client's own configuration.
+    test-timeout        Send timeout test event.
+
+environment variables:
+
+    ZEEK_CLIENT_CONFIG_FILE:      Same as `--configfile` argument, but lower precedence.
+    ZEEK_CLIENT_CONFIG_SETTINGS:  Same as a space-separated series of `--set` arguments, but lower precedence.
+```
+
+## Installation
+
+Due to the dependency on Broker we don't currently offer a standalone package to
+install via `pip`. Instead, the recommended way to run the client is to install
+Zeek, since the client ships with it, or run it directly from the official Zeek
+[docker image](https://hub.docker.com/r/zeekurity/zeek).
+
+With Broker's new support for [WebSocket data
+transport](https://docs.zeek.org/projects/broker/en/current/web-socket.html)
+we'll be able to simplify stand-alone client installation.
+
+## Quickstart
+
+Run the following (as root) to launch an all-in-one management instance on your
+system:
+
+```console
+# zeek -C -j policy/frameworks/management/controller policy/frameworks/management/agent
+```
+
+The above will stay in the foreground. In a new shell, save the following
+content to a file ``cluster.cfg`` and adapt the worker's sniffing interfaces to
+your system:
+
+```ini
+[manager]
+role = manager
+
+[logger]
+role = logger
+
+[worker-01]
+role = worker
+interface = lo
+
+[worker-02]
+role = worker
+interface = eth0
+```
+
+Run the following command (as any user) to deploy the configuration:
+
+```console
+$ zeek-client deploy-config cluster.cfg
+{
+  "errors": [],
+  "results": {
+    "id": "9befc56c-f7e8-11ec-8626-7c10c94416bb",
+    "nodes": {
+      "logger": {
+        "instance": "agent-testbox",
+        "success": true
+      },
+      "manager": {
+        "instance": "agent-testbox",
+        "success": true
+      },
+      "worker-01": {
+        "instance": "agent-testbox",
+        "success": true
+      },
+      "worker-02": {
+        "instance": "agent-testbox",
+        "success": true
+      }
+    }
+  }
+}
+```
+
+You are now running a Zeek cluster on your system. Try ``zeek-client get-nodes``
+to see more details about the cluster's current status. (In the above, "testbox"
+is the system's hostname.)
+
+## Documentation
+
+The [Zeek documentation](https://docs.zeek.org/en/master/frameworks/management.html)
+covers both the Management framework and the client's commands.

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -275,23 +275,6 @@ role = manager
             self.logbuf.getvalue(),
             'error: invalid node "manager" configuration: node requires an instance')
 
-    def test_config_missing_instance(self):
-        ini_input = """
-[instances]
-agent
-
-[manager]
-port = 80
-role = manager
-"""
-        cfp = self.parserFromString(ini_input)
-        config = zeekclient.Configuration.from_config_parser(cfp)
-        self.assertFalse(config)
-
-        self.assertEqualStripped(
-            self.logbuf.getvalue(),
-            'error: invalid node "manager" configuration: node requires an instance')
-
     def test_config_missing_role(self):
         ini_input = """
 [instances]

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -264,7 +264,6 @@ role = manager
 agent
 
 [manager]
-port = 80
 role = manager
 """
         cfp = self.parserFromString(ini_input)
@@ -273,7 +272,24 @@ role = manager
 
         self.assertEqualStripped(
             self.logbuf.getvalue(),
-            'error: invalid node "manager" configuration: node requires an instance')
+            'error: omit instances section when skipping instances in node definitions')
+
+    def test_config_mixed_instances(self):
+        ini_input = """
+[manager]
+role = manager
+
+[worker]
+role = worker
+instance = agent1
+"""
+        cfp = self.parserFromString(ini_input)
+        config = zeekclient.Configuration.from_config_parser(cfp)
+        self.assertFalse(config)
+
+        self.assertEqualStripped(
+            self.logbuf.getvalue(),
+            'error: either all or no nodes must state instances')
 
     def test_config_missing_role(self):
         ini_input = """

--- a/zeekclient/types.py
+++ b/zeekclient/types.py
@@ -508,7 +508,7 @@ class Configuration(BrokerType, ConfigParserMixin):
             # All keys for sections other than "instances" need to have a value.
             for key, val in cfp.items(section):
                 if val is None:
-                    LOG.error('config item %s/%s needs a value', section, key)
+                    LOG.error('config item %s.%s needs a value', section, key)
                     return None
 
             # The other sections are cluster nodes. Each section name corresponds to

--- a/zeekclient/types.py
+++ b/zeekclient/types.py
@@ -3,6 +3,7 @@ import configparser
 import enum
 import ipaddress
 import shlex
+import socket
 
 import broker
 
@@ -337,7 +338,11 @@ class Node(BrokerType, ConfigParserMixin):
 
         # Validate the specified values
         if not instance:
-            raise ValueError('node requires an instance')
+            # When a node features no instance name, default to
+            # "agent-<hostname>", assuming the config targets host-local
+            # deployment.
+            hostname = socket.gethostname() or 'localhost'
+            instance = 'agent-' + hostname
 
         if not role:
             raise ValueError('node requires a role')


### PR DESCRIPTION
When running all cluster management (controller, agent, and client) on a single machine, the need to specify an instance at all is a hassle and we can imply the local instance. This also means that examples become fully self-contained since installation-specific details like the hostname no longer show up.

Also fleshes out README and adds the usual license.