### PR TITLE
Event-filtering fixes

### DIFF
--- a/tests/broker.py
+++ b/tests/broker.py
@@ -44,9 +44,10 @@ class Endpoint:
 
 
 class Subscriber:
-    def __init_(self):
-        self.topic = ""
-        self.data = ()
+    def __init__(self):
+        # A sequence of (topic, data) tuples, that iterative
+        # get() calls will retrieve tuple by tuple.
+        self.mock_data = []
 
     def available(self):
         return True
@@ -55,7 +56,8 @@ class Subscriber:
         return 0
 
     def get(self, secs=None, num=None):
-        return self.topic, self.data
+        assert self.mock_data, 'subscriber mock ran out of data'
+        return self.mock_data.pop(0)
 
 
 class SafeSubscriber(Subscriber):

--- a/zeekclient/events.py
+++ b/zeekclient/events.py
@@ -112,7 +112,7 @@ class Registry:
 
 DeployRequest = Registry.make_event_class(
     'Management::Controller::API::deploy_request',
-    ('requid',), (str,))
+    ('reqid',), (str,))
 
 DeployResponse = Registry.make_event_class(
     'Management::Controller::API::deploy_response',


### PR DESCRIPTION
The client was so far not robust at all to unexpected response data (i.e., any events not in response to request events it had just submitted). This makes the client skip any unexpected responses. Timeouts etc still apply, but such unexpected responses simply get dropped on the floor. A unit test covers this, and in local testing I can now run multiple clients in parallel against the same controller.