### PR TITLE
Fix for infinite connection attempts and some minor cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,6 @@ sys.path.insert(0, TESTS)
 # via it. This allows tests to run without package installation.
 sys.path.insert(0, ROOT)
 
-# This is the mock, not the real one
-import websocket
-
 import zeekclient as zc
 
 class TestCliInvocation(unittest.TestCase):
@@ -31,14 +28,14 @@ class TestCliInvocation(unittest.TestCase):
 
     def test_help(self):
         cproc = subprocess.run([os.path.join(ROOT, 'zeek-client'), '--help'],
-                               env=self.env, capture_output=True)
+                               check=True, env=self.env, capture_output=True)
         self.assertEqual(cproc.returncode, 0)
 
     def test_show_settings(self):
         env = os.environ.copy()
         env['PYTHONPATH'] = os.pathsep.join(sys.path)
         cproc = subprocess.run([os.path.join(ROOT, 'zeek-client'), 'show-settings'],
-                               env=self.env, capture_output=True)
+                               check=True, env=self.env, capture_output=True)
         self.assertEqual(cproc.returncode, 0)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,7 +111,7 @@ class TestCli(unittest.TestCase):
         args = parser.parse_args(inargs)
 
         def mock_create_controller():
-            self.controller.wsock.mock_connect_oserror = True
+            self.controller.wsock.mock_connect_exc = OSError()
             self.controller.connect()
             return None
         zc.cli.create_controller = mock_create_controller
@@ -127,7 +127,7 @@ class TestCli(unittest.TestCase):
 
         def mock_create_controller():
             self.controller.connect()
-            self.controller.wsock.mock_recv_oserror = True
+            self.controller.wsock.mock_recv_exc = OSError()
             return self.controller
         zc.cli.create_controller = mock_create_controller
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -6,7 +6,6 @@ controller), and serialize them correctly to INI/JSON.
 import configparser
 import io
 import json
-import logging
 import os
 import sys
 import unittest

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -3,12 +3,7 @@
 individual settings via command-line arguments, environment variables, and
 files.
 """
-import configparser
-import io
-import json
-import logging
 import os
-import shutil
 import sys
 import tempfile
 import unittest
@@ -40,9 +35,10 @@ class TestConfig(unittest.TestCase):
             self.config.update_from_file(hdl.name)
             self.assertEqual(self.config.getint('client', 'request_timeout_secs'), 10)
 
+    @unittest.mock.patch.dict(
+        os.environ, {'ZEEK_CLIENT_CONFIG_SETTINGS':
+                     'client.request_timeout_secs=23 server.FOO="1 2 3"'})
     def test_update_from_env(self):
-        old = os.getenv('ZEEK_CLIENT_CONFIG_SETTINGS')
-        os.environ['ZEEK_CLIENT_CONFIG_SETTINGS'] = 'client.request_timeout_secs=23 server.FOO="1 2 3"'
         self.config.update_from_env()
         self.assertEqual(self.config.getint('client', 'request_timeout_secs'), 23)
         self.assertEqual(self.config.get('server', 'FOO'), '1 2 3')

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -105,6 +105,17 @@ class TestController(unittest.TestCase):
             with self.assertRaises(zeekclient.controller.ConfigError):
                 controller = zeekclient.controller.Controller()
 
+    def test_connect_fails_with_refused(self):
+        controller = zeekclient.controller.Controller()
+        controller.wsock.mock_connect_refused = True
+        # Dial down attempts and waits to make this fast:
+        zeekclient.CONFIG.set('client', 'peering_attempts', '2')
+        zeekclient.CONFIG.set('client', 'peering_retry_delay_secs', '0.1')
+        self.assertFalse(controller.connect())
+        self.assertLogLines(
+            'info: connecting to controller 127.0.0.1:2149',
+            'error: websocket connection to 127.0.0.1:2149 timed out in connect\(\)')
+
     def test_connect_fails_with_timeout(self):
         controller = zeekclient.controller.Controller()
         controller.wsock.mock_connect_timeout = True

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,12 +1,8 @@
 #! /usr/bin/env python
 """This verifies zeekclient.controller.Controller's behavior."""
-import configparser
 import io
-import json
-import logging
 import os
 import re
-import select
 import ssl
 import sys
 import unittest

--- a/tests/websocket.py
+++ b/tests/websocket.py
@@ -24,6 +24,7 @@ class WebSocket():
         # to retrieve that from real instances.
         self.mock_url = None
 
+        self.mock_connect_refused = False
         self.mock_connect_timeout = False
         self.mock_connect_websocket_exception = False
         self.mock_connect_sslerror = False
@@ -46,6 +47,8 @@ class WebSocket():
         self.mock_send_queue = []
 
     def connect(self, url, **options):
+        if self.mock_connect_refused:
+            raise ConnectionRefusedError()
         if self.mock_connect_timeout:
             raise WebSocketTimeoutException('connection timed out')
         if self.mock_connect_websocket_exception:

--- a/tests/websocket.py
+++ b/tests/websocket.py
@@ -3,7 +3,6 @@
 For details, see https://github.com/websocket-client/websocket-client.
 """
 
-import ssl
 import zeekclient
 
 class WebSocketException(Exception):
@@ -24,17 +23,11 @@ class WebSocket():
         # to retrieve that from real instances.
         self.mock_url = None
 
-        self.mock_connect_refused = False
-        self.mock_connect_timeout = False
-        self.mock_connect_websocket_exception = False
-        self.mock_connect_sslerror = False
-        self.mock_connect_oserror = False
-        self.mock_connect_unknown_exception = False
-
-        self.mock_recv_timeout = False
-        self.mock_recv_websocket_exception = False
-        self.mock_recv_oserror = False
-        self.mock_recv_unknown_exception = False
+        # Exception instances in case we want to trigger problems during I/O.
+        # These correspond to the exceptions handled in Controller.connect()'s
+        # wsock_operation() inner function.
+        self.mock_connect_exc = None
+        self.mock_recv_exc = None
 
         self.mock_broker_id = 'broker-id-aaa'
 
@@ -47,18 +40,8 @@ class WebSocket():
         self.mock_send_queue = []
 
     def connect(self, url, **options):
-        if self.mock_connect_refused:
-            raise ConnectionRefusedError()
-        if self.mock_connect_timeout:
-            raise WebSocketTimeoutException('connection timed out')
-        if self.mock_connect_websocket_exception:
-            raise WebSocketException('uh-oh')
-        if self.mock_connect_sslerror:
-            raise ssl.SSLError('dummy library version', 'uh-oh')
-        if self.mock_connect_oserror:
-            raise OSError('uh-oh')
-        if self.mock_connect_unknown_exception:
-            raise UnknownException('surprise')
+        if self.mock_connect_exc is not None:
+            raise self.mock_connect_exc
 
         self.mock_url = url
 
@@ -66,14 +49,8 @@ class WebSocket():
         self.mock_send_queue.append(payload)
 
     def recv(self):
-        if self.mock_recv_timeout:
-            raise WebSocketTimeoutException('connection timed out')
-        if self.mock_recv_websocket_exception:
-            raise WebSocketException('uh-oh')
-        if self.mock_recv_oserror:
-            raise OSError('uh-oh')
-        if self.mock_recv_unknown_exception:
-            raise UnknownException('surprise')
+        if self.mock_recv_exc is not None:
+            raise self.mock_recv_exc
 
         assert self.mock_recv_queue, 'socket mock ran out of data'
         return self.mock_recv_queue.pop(0)

--- a/zeekclient/controller.py
+++ b/zeekclient/controller.py
@@ -108,10 +108,10 @@ class Controller:
 
             while attempts > 0:
                 try:
+                    attempts -= 1
                     return op()
                 except websocket.WebSocketTimeoutException:
                     time.sleep(retry_delay)
-                    attempts -= 1
                     continue
                 except websocket.WebSocketException as err:
                     LOG.error('websocket error in %s with controller %s:%s: %s',


### PR DESCRIPTION
Connecting to a non-existant controller could hit an infinite-retries loop because of a straightforward bug in the retry logic. A unit test now verifies that this works. Also contains minor cleanups.