### PR TITLE
Relax Event validation

### DIFF
--- a/tests/test_brokertypes.py
+++ b/tests/test_brokertypes.py
@@ -387,6 +387,28 @@ class TestBrokertypes(unittest.TestCase):
         with self.assertRaises(TypeError):
             ZeekEvent('foo', 1)
 
+    def test_zeek_event_from_vector_metadata(self):
+        md_vec = Vector([Vector([from_py(12344242), from_py('truth')])])
+        args_vec = Vector()
+        ev_vec = Vector([from_py('Test::event'), args_vec, md_vec])
+        vec = Vector([from_py(1), from_py(1), ev_vec])
+
+        ev = ZeekEvent.from_vector(vec)
+        self.assertEqual(ev.name, "Test::event")
+        self.assertEqual(ev.args, [])
+
+    def test_zeek_event_from_vector_invalid(self):
+        test_cases = [
+            ("missing args", Vector([from_py('Test::event')])),
+            ("wrong name type", Vector([from_py(1), Vector()])),
+            ("wrong args type", Vector([from_py('Test::event'), from_py('string')])),
+        ]
+
+        for (name, vec) in test_cases:
+            with self.subTest(msg=name):
+                with self.assertRaises(TypeError):
+                    ZeekEvent.from_vector(vec)
+
     def test_handshake_message(self):
         self.assertEqual(HandshakeMessage(['foo', 'bar']),
                          HandshakeMessage(['foo', String('bar')]))

--- a/zeekclient/brokertypes.py
+++ b/zeekclient/brokertypes.py
@@ -817,15 +817,18 @@ class ZeekEvent(Vector):
         if not isinstance(vec, Vector):
             raise TypeError('cannot convert non-vector to Zeek event')
 
-        if (not len(vec) == 3 or
+        if (len(vec) < 3 or
             not isinstance(vec[2], Vector) or
-            not len(vec[2]) == 2 or
+            len(vec[2]) < 2 or
             not isinstance(vec[2][0], String) or
             not isinstance(vec[2][1], Vector)):
             raise TypeError('invalid vector layout for Zeek event')
 
         name = vec[2][0].to_py()
         args = vec[2][1]
+
+        # TODO: Extend to handle metadata
+
         return ZeekEvent(name, *args._elements)
 
     @classmethod


### PR DESCRIPTION
Changes to add metadata to Zeek events require clients to be more lax in what they expect. Loosen the validation to allow for more element in vectors rather than being overly strict.

This does not implement handling/recognizing of metadata attached to events - only makes it compatible with the most recent Zeek development version.