### PR TITLE
Fix Zeek-bundled install's Python module handling; add test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,9 @@ jobs:
     if: github.repository == 'zeek/zeek-client'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pylint
+          pip install pylint websocket-client
       - name: Run unit tests
         run: cd tests && python -m unittest -v
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 import unittest
 
+from contextlib import contextmanager
+
 TESTS = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.normpath(os.path.join(TESTS, '..'))
 
@@ -18,6 +20,18 @@ sys.path.insert(0, TESTS)
 sys.path.insert(0, ROOT)
 
 import zeekclient as zc
+
+# A context guard to switch the current working directory.
+# With 3.11 this can go and become contextlib.chdir():
+@contextmanager
+def setdir(path):
+    origin = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(origin)
+
 
 class TestCliInvocation(unittest.TestCase):
     # This invokes the zeek-client toplevel script.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ import zeekclient as zc
 class TestCliInvocation(unittest.TestCase):
     # This invokes the zeek-client toplevel script.
     def setUp(self):
-        # Set up an environment in which subprocesses pick up our stub Broker fist:
+        # Set up an environment in which subprocesses pick up our package first:
         self.env = os.environ.copy()
         self.env['PYTHONPATH'] = os.pathsep.join(sys.path)
 
@@ -32,8 +32,6 @@ class TestCliInvocation(unittest.TestCase):
         self.assertEqual(cproc.returncode, 0)
 
     def test_show_settings(self):
-        env = os.environ.copy()
-        env['PYTHONPATH'] = os.pathsep.join(sys.path)
         cproc = subprocess.run([os.path.join(ROOT, 'zeek-client'), 'show-settings'],
                                check=True, env=self.env, capture_output=True)
         self.assertEqual(cproc.returncode, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,10 @@
 import io
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 
 from contextlib import contextmanager
@@ -49,6 +51,41 @@ class TestCliInvocation(unittest.TestCase):
         cproc = subprocess.run([os.path.join(ROOT, 'zeek-client'), 'show-settings'],
                                check=True, env=self.env, capture_output=True)
         self.assertEqual(cproc.returncode, 0)
+
+
+class TestBundledCliInvocation(unittest.TestCase):
+
+    # Verify that zeek-client finds its package in Zeek-bundled install, where
+    # the package will not be in the usual Python search path. As we add more
+    # system-level testing, this may become a btest too, but for we stick to
+    # Python. Most system-level testing happens in the zeek-testing-cluster
+    # external testsuite.
+    @unittest.skipUnless(shutil.which('cmake') and shutil.which('make'),
+                         'needs both cmake and make in the system path')
+    def test_bundled_install(self):
+        with tempfile.TemporaryDirectory() as tmpdir, setdir(tmpdir):
+            # Configure the package via cmake with a Python module directory, as
+            # Zeek would do. Do this from the temp directory we're now in ...
+            cproc = subprocess.run(
+                ['cmake',
+                 '-D', f'PY_MOD_INSTALL_DIR={os.path.join(tmpdir, "python")}',
+                 f'--install-prefix={tmpdir}',
+                 ROOT],
+                check=True, capture_output=True)
+
+            # ... and install there too, into local bin/ and python/ dirs.
+            cproc = subprocess.run(['make', 'install'],
+                                   check=True, capture_output=True)
+
+            # We should now be able to run "./bin/zeek-client --help".
+            cproc = subprocess.run([os.path.join(tmpdir, 'bin', 'zeek-client'), '--help'],
+                                   capture_output=True)
+            if cproc.returncode != 0:
+                print('==== STDOUT ====')
+                print(cproc.stdout.decode('utf-8'))
+                print('==== STDERR ====')
+                print(cproc.stderr.decode('utf-8'))
+                self.fail('zeek-client invocation failed')
 
 
 class TestCliBasics(unittest.TestCase):

--- a/zeek-client
+++ b/zeek-client
@@ -22,6 +22,16 @@ try:
 except ImportError:
     pass
 
+# For Zeek-bundled installation, prepend the Python path of the Zeek
+# installation to the search path. This ensures we find the matching module
+# first (or at all), avoiding potential conflicts with installations elsewhere
+# on the system.
+ZEEK_PYTHON_DIR = "@PY_MOD_INSTALL_DIR@"
+if os.path.isdir(ZEEK_PYTHON_DIR):
+    sys.path.insert(0, os.path.abspath(ZEEK_PYTHON_DIR))
+else:
+    ZEEK_PYTHON_DIR = None
+
 import zeekclient  # pylint: disable=wrong-import-position
 
 


### PR DESCRIPTION
@dopheide-esnet spotted that `zeek-client` was still lacking the usual `sys.path` tweak to reliably locate its Zeek-bundled Python module. This adds this tweak and adds a test for it.