### PR TITLE
fix `deploy-config`/`stage-config` bug relative to `cpu_affinity` config field

### DIFF
--- a/zeekclient/types.py
+++ b/zeekclient/types.py
@@ -372,7 +372,7 @@ class Node(ZeekType, ConfigParserMixin):
                 bt.from_py(self.scripts),
                 options,
                 bt.from_py(self.interface),
-                bt.from_py(self.cpu_affinity, typ=bt.Count),
+                bt.from_py(self.cpu_affinity, typ=bt.Integer),
                 bt.from_py(self.env),
             ]
         )


### PR DESCRIPTION
## What
There is bug with `cpu_affinity` field in deploy configuration. When it's placed in config, commands like `deploy-config`/`stage-config` fail with "request timed out" error.
`Controller` expects an `Integer` type for the field but actually gets the `Count`.

The pull request provides a solution

## How
Just by correcting type for `cpu_affinity`

## Relative issues
Closes #34
