### PR TITLE
Additions for a metrics_port in the node state.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,6 +327,7 @@ class TestCli(unittest.TestCase):
       "env": {},
       "instance": "instance1",
       "interface": null,
+      "metrics_port": null,
       "name": "worker1",
       "options": null,
       "port": null,

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -30,6 +30,7 @@ agent
 instance = agent
 port = 5000
 role = manager
+metrics_port = 6000
 
 [logger-01]
 instance = agent
@@ -49,6 +50,7 @@ instance = agent
 role = worker
 interface = enp3s0
 cpu_affinity = 8
+metrics_port = 6001
 """
     INI_EXPECTED = """[instances]
 agent
@@ -63,6 +65,7 @@ scripts = foo/bar/baz
 instance = agent
 role = MANAGER
 port = 5000
+metrics_port = 6000
 
 [worker-01]
 instance = agent
@@ -76,6 +79,7 @@ instance = agent
 role = WORKER
 interface = enp3s0
 cpu_affinity = 8
+metrics_port = 6001
 """
     JSON_EXPECTED = """{
     "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -90,6 +94,7 @@ cpu_affinity = 8
             "env": {},
             "instance": "agent",
             "interface": null,
+            "metrics_port": null,
             "name": "logger-01",
             "options": null,
             "port": 5001,
@@ -103,6 +108,7 @@ cpu_affinity = 8
             "env": {},
             "instance": "agent",
             "interface": null,
+            "metrics_port": 6000,
             "name": "manager",
             "options": null,
             "port": 5000,
@@ -117,6 +123,7 @@ cpu_affinity = 8
             },
             "instance": "agent",
             "interface": "lo",
+            "metrics_port": null,
             "name": "worker-01",
             "options": null,
             "port": null,
@@ -128,6 +135,7 @@ cpu_affinity = 8
             "env": {},
             "instance": "agent",
             "interface": "enp3s0",
+            "metrics_port": 6001,
             "name": "worker-02",
             "options": null,
             "port": null,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -105,6 +105,7 @@ class TestTypes(unittest.TestCase):
             interface="eth0",
             cpu_affinity=13,
             env={"FOO": "BAR"},
+            metrics_port=9000,
         )
         val1 = self.brokertype_roundtrip(val0)
         self.assertEqual(val0, val1)

--- a/zeekclient/cli.py
+++ b/zeekclient/cli.py
@@ -565,6 +565,10 @@ def cmd_get_nodes(_args):
                     json_data["results"][res.instance][nstat.node]["pid"] = nstat.pid
                 if nstat.port is not None:
                     json_data["results"][res.instance][nstat.node]["port"] = nstat.port
+                if nstat.metrics_port is not None:
+                    json_data["results"][res.instance][nstat.node][
+                        "metrics_port"
+                    ] = nstat.metrics_port
         except TypeError as err:
             LOG.error("NodeStatus data invalid: %s", err)
             LOG.debug(traceback.format_exc())


### PR DESCRIPTION
This adds support for creating nodes with an optional metrics port, to read it from a .ini, and to serialize to/from JSON. Includes test cases.

Companion to zeek/zeek#3812.