### PR TITLE
Use correct types for websocket exceptions

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -139,7 +139,7 @@ class TestController(unittest.TestCase):
 
     def test_connect_fails_with_timeout(self):
         controller = zeekclient.controller.Controller()
-        controller.wsock.mock_connect_exc = websocket.WebSocketTimeoutError(
+        controller.wsock.mock_connect_exc = websocket.WebSocketTimeoutException(
             "connection timed out",
         )
         # Dial down attempts and waits to make this fast:
@@ -153,7 +153,7 @@ class TestController(unittest.TestCase):
 
     def test_connect_fails_with_websocket_error(self):
         controller = zeekclient.controller.Controller()
-        controller.wsock.mock_connect_exc = websocket.WebSocketError("uh-oh")
+        controller.wsock.mock_connect_exc = websocket.WebSocketException("uh-oh")
         self.assertFalse(controller.connect())
         self.assertLogLines(
             "info: connecting to controller 127.0.0.1:2149",
@@ -192,7 +192,7 @@ class TestController(unittest.TestCase):
 
     def test_handshake_fails_with_timeout(self):
         controller = zeekclient.controller.Controller()
-        controller.wsock.mock_recv_exc = websocket.WebSocketTimeoutError(
+        controller.wsock.mock_recv_exc = websocket.WebSocketTimeoutException(
             "connection timed out",
         )
         self.assertFalse(controller.connect())
@@ -278,7 +278,7 @@ class TestController(unittest.TestCase):
     def test_receive_fails_with_timeout(self):
         controller = zeekclient.controller.Controller()
         self.assertTrue(controller.connect())
-        controller.wsock.mock_recv_exc = websocket.WebSocketTimeoutError(
+        controller.wsock.mock_recv_exc = websocket.WebSocketTimeoutException(
             "connection timed out",
         )
         res, msg = controller.receive()

--- a/tests/websocket.py
+++ b/tests/websocket.py
@@ -6,11 +6,13 @@ For details, see https://github.com/websocket-client/websocket-client.
 import zeekclient
 
 
-class WebSocketError(Exception):
+# This typename needs to match the one in websocket-client or tests will fail.
+class WebSocketException(Exception):  # noqa: N818
     pass
 
 
-class WebSocketTimeoutError(WebSocketError):
+# This typename needs to match the one in websocket-client or tests will fail.
+class WebSocketTimeoutException(WebSocketException):  # noqa: N818
     pass
 
 

--- a/zeekclient/controller.py
+++ b/zeekclient/controller.py
@@ -108,10 +108,10 @@ class Controller:
                 try:
                     attempts -= 1
                     return op()
-                except websocket.WebSocketTimeoutError:
+                except websocket.WebSocketTimeoutException:
                     time.sleep(retry_delay)
                     continue
-                except websocket.WebSocketError as err:
+                except websocket.WebSocketException as err:
                     LOG.error(
                         "websocket error in %s with controller %s:%s: %s",
                         stage,
@@ -268,7 +268,7 @@ class Controller:
                         None,
                         f"protocol data error with controller {remote}: {err}",
                     )
-                except websocket.WebSocketTimeoutError:
+                except websocket.WebSocketTimeoutException:
                     return (
                         None,
                         f"websocket connection to {remote} timed out",


### PR DESCRIPTION
After the upgrade to Python 3.9, some of the types we were using for the websocket package changed. This fixes the code to use the right types.