### PR TITLE
Revert modification of sys.path when importing zeekclient

### DIFF
--- a/zeek-client
+++ b/zeek-client
@@ -13,9 +13,19 @@ the idioms and primitives also used by the zkg package manager.
 # https://pypi.org/project/argcomplete/#global-completion
 # PYTHON_ARGCOMPLETE_OK
 
+import os.path
 import sys
 
-import zeekclient
+# For Zeek-bundled installation, prepend the Python path of the Zeek
+# installation to the search path. This ensures we find the matching module
+# first (or at all), avoiding potential conflicts with installations elsewhere
+# on the system.
+ZEEK_PYTHON_DIR = "@PY_MOD_INSTALL_DIR@"
+if os.path.isdir(ZEEK_PYTHON_DIR):
+    sys.path.insert(0, os.path.abspath(ZEEK_PYTHON_DIR))
+else:
+    ZEEK_PYTHON_DIR = None
+import zeekclient  # pylint: disable=wrong-import-position
 
 
 def main():


### PR DESCRIPTION
This was removed in f93b8e193773a667eaaba5bb5f99cf05f1c478dd but causes problems on systems without Internet access.