### PR TITLE
Loosen the message I/O with the controller to not error out upon wrong message type

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -279,14 +279,12 @@ class TestController(unittest.TestCase):
         controller = zeekclient.controller.Controller()
         self.assertTrue(controller.connect())
         # Not a DataMessage:
-        controller.wsock.mock_recv_queue.append(
-            zeekclient.brokertypes.Count(1).serialize(),
-        )
+        controller.wsock.mock_recv_queue.append('{"type": "data-message"}')
         res, msg = controller.receive()
         self.assertIsNone(res)
         self.assertRegex(
             msg,
-            "protocol data error .+: invalid data layout for Broker MessageType",
+            "protocol data error .+: invalid data layout for DataMessage",
         )
 
     def test_receive_fails_with_timeout(self):

--- a/zeek-client
+++ b/zeek-client
@@ -25,6 +25,9 @@ if os.path.isdir(ZEEK_PYTHON_DIR):
     sys.path.insert(0, os.path.abspath(ZEEK_PYTHON_DIR))
 else:
     ZEEK_PYTHON_DIR = None
+
+import websocket  # pylint: disable=wrong-import-position
+
 import zeekclient  # pylint: disable=wrong-import-position
 
 
@@ -53,6 +56,9 @@ def main():
             zeekclient.CONFIG.getint("client", "verbosity"),
             zeekclient.CONFIG.getboolean("client", "rich_logging_format"),
         )
+
+        if zeekclient.CONFIG.getint("client", "verbosity") >= 4:
+            websocket.enableTrace(True)
 
     if not args.command:
         zeekclient.LOG.error("please provide a command to execute.")

--- a/zeekclient/config.py
+++ b/zeekclient/config.py
@@ -56,7 +56,8 @@ class Config(configparser.ConfigParser):
                     #   1   also warnings
                     #   2   also informational messages
                     #   3   also debug messages
-                    #   4+  no additional effect
+                    #   4   also trace websocket I/O
+                    #   5+  no additional effect
                     "verbosity": 0,
                 },
                 "controller": {

--- a/zeekclient/controller.py
+++ b/zeekclient/controller.py
@@ -10,6 +10,7 @@ from .brokertypes import (
     HandshakeAckMessage,
     HandshakeMessage,
     ZeekEvent,
+    unserialize,
 )
 from .config import CONFIG
 from .consts import CONTROLLER_TOPIC
@@ -270,7 +271,10 @@ class Controller:
                 # (2) ensure it's a data message
                 # (3) try to extract data message payload as event
                 try:
-                    msg = DataMessage.unserialize(self.wsock.recv())
+                    msg = unserialize(self.wsock.recv())
+                    if not isinstance(msg, DataMessage):
+                        LOG.debug("skipping unexpected received message %s", msg)
+                        continue
                 except TypeError as err:
                     return (
                         None,


### PR DESCRIPTION
There's new behavior in Zeek's WebSocket stack that causes Broker errors to shine through, which could confuse the client. Unexpected messages are now simply skipped.

This also adds a new debug level which traces the WebSocket I/O to stderr, helpful for debugging.