### PR TITLE
Update Github action to use trusted publishing and bump various versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -29,9 +29,9 @@ jobs:
           - "3.13"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -45,20 +45,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     if: github.repository == 'zeek/zeek-client' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/zeek-client
+    permissions:
+      id-token: write  # This uses trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check release version
         # This fails e.g. if VERSION contains a dev commits suffix,
         # since we don't want to push these to PyPI.
         run: |
           grep -E -x '[0-9]+\.[0-9]+\.[0-9]+' VERSION
-      - name: Build sdist
-        # This places the sdist in the dist folder, where the upload
+      - name: Build dist
+        # This places the release tarball in the dist folder, where the upload
         # action in the next step knows to look for it.
         run: |
           make dist
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I just stumbled over the fact that publishing to PyPI [no longer works](https://github.com/zeek/zeek-client/actions/runs/19051918324/job/54413945434), so this modernizes the setup.

See https://docs.pypi.org/trusted-publishers/ and
https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing